### PR TITLE
chore(release): publish scaffold (publishConfig + docs)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @rodriherrerab

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,29 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+      - master
+      - "rebrand/**"
+  pull_request:
+  schedule:
+    - cron: "10 3 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: javascript
+      - uses: github/codeql-action/autobuild@v3
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:javascript"

--- a/RELEASE_PLAN.md
+++ b/RELEASE_PLAN.md
@@ -1,0 +1,22 @@
+# Release Plan — Primea (Alpha Scaffold)
+
+This PR only adds publish scaffolding. No product code changes.
+
+## Now
+- Normalize `publishConfig` in every `package.json`.
+  - Public packages:
+    "publishConfig": {
+      "access": "public",
+      "registry": "https://registry.npmjs.org/",
+      "tag": "primea-alpha"
+    }
+  - Private packages:
+    "publishConfig": { "tag": "private-skip" }
+
+## Later
+- Keep names unchanged now; later publish under `@primea/*` from a dedicated `release/*` branch.
+- Workspace-aware publish (pnpm/yarn) with `--tag primea-alpha`.
+
+## Guardrails
+- Private packages tagged `private-skip` to avoid accidental publish.
+- Publish only from protected release branches.

--- a/RELEASE_PLAN.md
+++ b/RELEASE_PLAN.md
@@ -3,20 +3,23 @@
 This PR only adds publish scaffolding. No product code changes.
 
 ## Now
+
 - Normalize `publishConfig` in every `package.json`.
   - Public packages:
     "publishConfig": {
-      "access": "public",
-      "registry": "https://registry.npmjs.org/",
-      "tag": "primea-alpha"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/",
+    "tag": "primea-alpha"
     }
   - Private packages:
     "publishConfig": { "tag": "private-skip" }
 
 ## Later
+
 - Keep names unchanged now; later publish under `@primea/*` from a dedicated `release/*` branch.
 - Workspace-aware publish (pnpm/yarn) with `--tag primea-alpha`.
 
 ## Guardrails
+
 - Private packages tagged `private-skip` to avoid accidental publish.
 - Publish only from protected release branches.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "description": "Primea fork — independent fork of upstream Uniswap repo",
   "license": "GPL-2.0-or-later",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/",
+    "tag": "primea-alpha"
   },
   "version": "1.4.4",
   "homepage": "https://github.com/primeanetwork/v3-periphery#readme",


### PR DESCRIPTION
Normalize publish scaffolding across the repo:

- `publishConfig` in all `package.json` files (root + workspaces)
  - public → access=public, registry=https://registry.npmjs.org/, tag=primea-alpha
  - private → tag=private-skip
- Add `RELEASE_PLAN.md` with next-steps and guardrails.

No product code changes; safe to re-run.